### PR TITLE
Update README to show Python 3.12 requirement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ pancake /path/to/your/project --exclude "*.log" --exclude "build/*"
 
 ## Requirements
 
-- Python 3.6+
+- Python 3.12
 - `tree` command (installed on most Unix systems)
   - Ubuntu/Debian: `sudo apt-get install tree`
   - macOS: `brew install tree`


### PR DESCRIPTION
## Summary
- document Python 3.12 in README requirements

## Testing
- `python3 --version`


------
https://chatgpt.com/codex/tasks/task_e_68410e1473d0832f97ff2ce8a0898316