### PR TITLE
Handle zero total in progress bar

### DIFF
--- a/pancake.py
+++ b/pancake.py
@@ -43,6 +43,21 @@ class ProgressBar:
         else:
             self.iteration += 1
 
+        # If total is zero, display a completed bar immediately
+        if self.total == 0:
+            elapsed_time = time.time() - self.start_time
+            bar = '█' * self.width
+            formatted_percent = f"{100:.{self.decimals}f}%"
+            time_info = f"Elapsed: {self._format_time(elapsed_time)}"
+            progress_line = (
+                f"\r{self.prefix} |{bar}| {formatted_percent} {self.suffix} "
+                f"| 0/0 | {time_info}"
+            )
+            sys.stdout.write(progress_line)
+            sys.stdout.flush()
+            print()
+            return
+
         # Limit update frequency to reduce terminal flicker
         current_time = time.time()
         if current_time - self.last_update_time < self.update_interval and self.iteration < self.total:

--- a/tests/test_progressbar.py
+++ b/tests/test_progressbar.py
@@ -1,0 +1,10 @@
+from pancake import ProgressBar
+
+
+def test_progressbar_zero_total(capsys):
+    pb = ProgressBar(total=0, width=10, prefix='Progress:', suffix='Done', decimals=1)
+    pb.update()
+    captured = capsys.readouterr().out
+    assert '100.0%' in captured
+    assert '0/0' in captured
+


### PR DESCRIPTION
## Summary
- print a completed bar when the total is zero
- add a regression test for the zero-files scenario

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410e134048832f94909b5e82f1ea1e